### PR TITLE
ARM clock configuration, IPG selection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ cortex-m = "0.6"
 
 [dependencies.imxrt-ccm]
 features = ["imxrt-ral"]
-git = "https://github.com/imxrt-rs/imxrt-ccm.git"
-rev = "0c93478"
+path = "../ccm"
 
 [dependencies.imxrt-dma]
 git = "https://github.com/imxrt-rs/imxrt-dma"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ cortex-m = "0.6"
 
 [dependencies.imxrt-ccm]
 features = ["imxrt-ral"]
-path = "../ccm"
+git = "https://github.com/imxrt-rs/imxrt-ccm"
+rev = "e89920e"
 
 [dependencies.imxrt-dma]
 git = "https://github.com/imxrt-rs/imxrt-dma"

--- a/examples/teensy4/src/bin/gpio.rs
+++ b/examples/teensy4/src/bin/gpio.rs
@@ -55,7 +55,7 @@ fn main() -> ! {
     let (_, _, mut blink_timer) = hal::ral::gpt::GPT1::take()
         .map(|mut inst| {
             perclock.set_clock_gate_gpt(&mut inst, hal::ccm::ClockGate::On);
-            hal::GPT::new(inst, &perclock)
+            hal::GPT::new(inst, &perclock, &handle)
         })
         .unwrap();
     let ones = async {

--- a/examples/teensy4/src/bin/gpt.rs
+++ b/examples/teensy4/src/bin/gpt.rs
@@ -25,7 +25,11 @@ fn main() -> ! {
     } = hal::ral::ccm::CCM::take()
         .map(hal::ccm::CCM::from_ral)
         .unwrap();
-    let mut perclock = perclock.enable(&mut handle);
+    let (arm, ipg) = handle.set_frequency_arm(600_000_000);
+    assert_eq!(arm.0, 600_000_000);
+    assert_eq!(ipg.0, 150_000_000);
+    let mut perclock =
+        perclock.enable_selection_divider(&mut handle, hal::ccm::perclock::Selection::IPG, 15);
 
     let mut gpt = hal::ral::gpt::GPT1::take().unwrap();
     perclock.set_clock_gate_gpt(&mut gpt, hal::ccm::ClockGate::On);

--- a/examples/teensy4/src/bin/gpt.rs
+++ b/examples/teensy4/src/bin/gpt.rs
@@ -18,15 +18,19 @@ fn main() -> ! {
     let mut led = hal::gpio::GPIO::new(pins.p13).output();
     let mut pin14 = hal::gpio::GPIO::new(pins.p14).output();
 
-    let mut ccm = hal::ral::ccm::CCM::take()
+    let hal::ccm::CCM {
+        mut handle,
+        perclock,
+        ..
+    } = hal::ral::ccm::CCM::take()
         .map(hal::ccm::CCM::from_ral)
         .unwrap();
-    let mut perclock = ccm.perclock.enable(&mut ccm.handle);
+    let mut perclock = perclock.enable(&mut handle);
 
     let mut gpt = hal::ral::gpt::GPT1::take().unwrap();
     perclock.set_clock_gate_gpt(&mut gpt, hal::ccm::ClockGate::On);
 
-    let (mut blink_timer, mut gpio_timer, _) = hal::GPT::new(gpt, &perclock);
+    let (mut blink_timer, mut gpio_timer, _) = hal::GPT::new(gpt, &perclock, &handle);
     let blink_loop = async {
         loop {
             blink_timer.delay(Duration::from_millis(250)).await;

--- a/examples/teensy4/src/bin/i2c.rs
+++ b/examples/teensy4/src/bin/i2c.rs
@@ -65,7 +65,7 @@ fn main() -> ! {
     let (mut timer, _, _) = GPT1::take()
         .map(|mut inst| {
             perclock.set_clock_gate_gpt(&mut inst, ccm::ClockGate::On);
-            GPT::new(inst, &perclock)
+            GPT::new(inst, &perclock, &handle)
         })
         .unwrap();
     let mut i2c_clock = i2c_clock.enable(&mut handle);

--- a/examples/teensy4/src/bin/pipe.rs
+++ b/examples/teensy4/src/bin/pipe.rs
@@ -44,6 +44,7 @@ fn main() -> ! {
             })
             .unwrap(),
         &perclock,
+        &handle,
     );
 
     let mut dmas = hal::dma::channels(

--- a/examples/teensy4/src/bin/pit.rs
+++ b/examples/teensy4/src/bin/pit.rs
@@ -15,6 +15,7 @@ fn main() -> ! {
     let pads = hal::iomuxc::new(hal::ral::iomuxc::IOMUXC::take().unwrap());
     let pins = teensy4_pins::t40::into_pins(pads);
     let mut led = hal::gpio::GPIO::new(pins.p13).output();
+    let mut pin14 = hal::gpio::GPIO::new(pins.p14).output();
 
     let hal::ccm::CCM {
         mut handle,
@@ -23,19 +24,30 @@ fn main() -> ! {
     } = hal::ral::ccm::CCM::take()
         .map(hal::ccm::CCM::from_ral)
         .unwrap();
-    let mut perclock = perclock.enable(&mut handle);
+    let (arm, ipg) = handle.set_frequency_arm(600_000_000);
+    assert_eq!(arm.0, 600_000_000);
+    assert_eq!(ipg.0, 150_000_000);
+    let mut perclock =
+        perclock.enable_selection_divider(&mut handle, hal::ccm::perclock::Selection::IPG, 15);
 
     let mut pit = hal::ral::pit::PIT::take().unwrap();
     perclock.set_clock_gate_pit(&mut pit, hal::ccm::ClockGate::On);
 
-    let (mut pit, _, _, _) = hal::PIT::new(pit, &perclock, &handle);
-    let blink_loop = async {
+    let (mut led_timer, mut gpio_timer, _, _) = hal::PIT::new(pit, &perclock, &handle);
+    let led_loop = async {
         loop {
-            pit.delay(core::time::Duration::from_millis(250)).await;
+            led_timer
+                .delay(core::time::Duration::from_millis(250))
+                .await;
             led.toggle();
         }
     };
-
-    async_embedded::task::block_on(blink_loop);
+    let gpio_loop = async {
+        loop {
+            gpio_timer.delay_us(333_000).await;
+            pin14.toggle();
+        }
+    };
+    async_embedded::task::block_on(futures::future::join(led_loop, gpio_loop));
     unreachable!();
 }

--- a/examples/teensy4/src/bin/spi.rs
+++ b/examples/teensy4/src/bin/spi.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     let mut spi_clock = spi_clock.enable(&mut handle);
     perclock.set_clock_gate_gpt(&mut gpt, hal::ccm::ClockGate::On);
 
-    let (mut timer, _, _) = hal::GPT::new(gpt, &perclock);
+    let (mut timer, _, _) = hal::GPT::new(gpt, &perclock, &handle);
     let mut channels = hal::dma::channels(
         hal::ral::dma0::DMA0::take()
             .map(|mut dma| {

--- a/examples/teensy4/src/bin/uart.rs
+++ b/examples/teensy4/src/bin/uart.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
     let mut perclock = perclock.enable(&mut handle);
     perclock.set_clock_gate_gpt(&mut gpt, hal::ccm::ClockGate::On);
 
-    let (mut timer, _, _) = hal::GPT::new(gpt, &perclock);
+    let (mut timer, _, _) = hal::GPT::new(gpt, &perclock, &handle);
     let mut channels = hal::dma::channels(
         hal::ral::dma0::DMA0::take()
             .map(|mut dma| {

--- a/src/ccm.rs
+++ b/src/ccm.rs
@@ -1,0 +1,49 @@
+//! Clock control module (CCM)
+//!
+//! The clocks and types exposed in `ccm` support clock control and peripheral clock
+//! gating. Use [`CCM::from_ral`](CCM) to acquire the clock roots and the
+//! CCM handle. Then, enable your clocks.
+//!
+//! ```no_run
+//! use imxrt_async_hal as hal;
+//! use hal::{ccm, ral};
+//!
+//! let ccm::CCM {
+//!     mut handle,
+//!     uart_clock,
+//!     ..
+//! } = ral::ccm::CCM::take().map(ccm::CCM::from_ral).unwrap();
+//!
+//! let mut uart_clock = uart_clock.enable(&mut handle);
+//! ```
+//!
+//! Clocks can enable peripheral clock gates, and they may be used in APIs that require
+//! you to first initialize clocks.
+//!
+//! ```no_run
+//! # use imxrt_async_hal as hal;
+//! # use hal::{ccm, ral};
+//! # let ccm::CCM {
+//! #     mut handle,
+//! #     uart_clock,
+//! #     ..
+//! # } = ral::ccm::CCM::take().map(ccm::CCM::from_ral).unwrap();
+//! # let mut uart_clock = uart_clock.enable(&mut handle);
+//! type UART2 = hal::instance::UART<hal::iomuxc::consts::U2>;
+//! let mut lpuart2: UART2 = ral::lpuart::LPUART2::take().and_then(hal::instance::uart).unwrap();
+//!
+//! // Enable the clock gate:
+//! uart_clock.set_clock_gate(&mut lpuart2, ccm::ClockGate::On);
+//!
+//! // Create the peripheral... see UART documentation for more information.
+//! ```
+
+pub use imxrt_ccm::{
+    ral::{I2CClock, PerClock, SPIClock, UARTClock, CCM},
+    ClockGate, Handle,
+};
+
+/// Periodic clock (PIT, GPT) types
+pub mod perclock {
+    pub use imxrt_ccm::perclock::Selection;
+}

--- a/src/dma/pipe.rs
+++ b/src/dma/pipe.rs
@@ -30,17 +30,17 @@
 //! use hal::{ccm::{CCM, ClockGate}, dma};
 //! use hal::ral::{ccm, dma0, dmamux, gpt::GPT1};
 //!
-//! let mut ccm = ccm::CCM::take().map(CCM::from_ral).unwrap();
-//! let mut perclock = ccm.perclock.enable(&mut ccm.handle);
+//! let CCM { mut handle, perclock, .. } = ccm::CCM::take().map(CCM::from_ral).unwrap();
+//! let mut perclock = perclock.enable(&mut handle);
 //! let (_, mut gpt, _) = GPT1::take()
 //!     .map(|mut inst| {
 //!         perclock.set_clock_gate_gpt(&mut inst, ClockGate::On);
-//!         hal::GPT::new(inst, &mut perclock)
+//!         hal::GPT::new(inst, &perclock, &handle)
 //!     })
 //!     .unwrap();
 //!
 //! let mut dma = dma0::DMA0::take().unwrap();
-//! ccm.handle.set_clock_gate_dma(&mut dma, ClockGate::On);
+//! handle.set_clock_gate_dma(&mut dma, ClockGate::On);
 //!
 //! let mut channels = dma::channels(
 //!     dma,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,52 +214,7 @@ macro_rules! handler {
 //
 // Modules
 //
-pub mod ccm {
-    //! Clock control module (CCM)
-    //!
-    //! The clocks and types exposed in `ccm` support clock control and peripheral clock
-    //! gating. Use [`CCM::from_ral`](CCM) to acquire the clock roots and the
-    //! CCM handle. Then, enable your clocks.
-    //!
-    //! ```no_run
-    //! use imxrt_async_hal as hal;
-    //! use hal::{ccm, ral};
-    //!
-    //! let ccm::CCM {
-    //!     mut handle,
-    //!     uart_clock,
-    //!     ..
-    //! } = ral::ccm::CCM::take().map(ccm::CCM::from_ral).unwrap();
-    //!
-    //! let mut uart_clock = uart_clock.enable(&mut handle);
-    //! ```
-    //!
-    //! Clocks can enable peripheral clock gates, and they may be used in APIs that require
-    //! you to first initialize clocks.
-    //!
-    //! ```no_run
-    //! # use imxrt_async_hal as hal;
-    //! # use hal::{ccm, ral};
-    //! # let ccm::CCM {
-    //! #     mut handle,
-    //! #     uart_clock,
-    //! #     ..
-    //! # } = ral::ccm::CCM::take().map(ccm::CCM::from_ral).unwrap();
-    //! # let mut uart_clock = uart_clock.enable(&mut handle);
-    //! type UART2 = hal::instance::UART<hal::iomuxc::consts::U2>;
-    //! let mut lpuart2: UART2 = ral::lpuart::LPUART2::take().and_then(hal::instance::uart).unwrap();
-    //!
-    //! // Enable the clock gate:
-    //! uart_clock.set_clock_gate(&mut lpuart2, ccm::ClockGate::On);
-    //!
-    //! // Create the peripheral... see UART documentation for more information.
-    //! ```
-
-    pub use imxrt_ccm::{
-        ral::{I2CClock, PerClock, SPIClock, UARTClock, CCM},
-        ClockGate, Handle,
-    };
-}
+pub mod ccm;
 #[cfg(any(feature = "pipe", feature = "spi", feature = "uart"))]
 #[cfg_attr(
     docsrs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //! // Enable the periodic clock for the GPT
 //! let mut perclock = perclock.enable(&mut handle);
 //! perclock.set_clock_gate_gpt(&mut gpt, hal::ccm::ClockGate::On);
-//! let (mut timer, _, _) = hal::GPT::new(gpt, &perclock);
+//! let (mut timer, _, _) = hal::GPT::new(gpt, &perclock, &handle);
 //!
 //! // Acquire DMA channels, which are used to schedule UART transfers
 //! let mut channels = hal::dma::channels(


### PR DESCRIPTION
The PR demonstrates how one can configure the ARM clock, and use the IPG clock as the periodic clock input. See imxrt-rs/imxrt-ccm#2 for more details.